### PR TITLE
Add JSON output to Bme680.Samples app

### DIFF
--- a/Bme680.Samples/Bme680.Samples.csproj
+++ b/Bme680.Samples/Bme680.Samples.csproj
@@ -6,6 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Bme680\Bme680.csproj" />
   </ItemGroup>
 

--- a/Bme680.Samples/Options.cs
+++ b/Bme680.Samples/Options.cs
@@ -12,5 +12,11 @@ namespace Bme680.Samples
         /// </summary>
         [Option('j', "json", Default = false, HelpText = "Output readings as JSON")]
         public bool JsonOutput { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether any non-reading output should be suppressed.
+        /// </summary>
+        [Option('q', "quiet", Default = false, HelpText = "Suppresses non-reading output")]
+        public bool Quiet { get; set; }
     }
 }

--- a/Bme680.Samples/Options.cs
+++ b/Bme680.Samples/Options.cs
@@ -1,0 +1,16 @@
+﻿using CommandLine;
+
+namespace Bme680.Samples
+{
+    /// <summary>
+    /// Defines options that can be passed to the program from the command line.
+    /// </summary>
+    public class Options
+    {
+        /// <summary>
+        /// Gets or sets the format to use when writing readings to the console.
+        /// </summary>
+        [Option('f', "format", Default = "text", HelpText = "Set format of output (text, json)")]
+        public string Format { get; set; }
+    }
+}

--- a/Bme680.Samples/Options.cs
+++ b/Bme680.Samples/Options.cs
@@ -8,9 +8,9 @@ namespace Bme680.Samples
     public class Options
     {
         /// <summary>
-        /// Gets or sets the format to use when writing readings to the console.
+        /// Gets or sets whether output should be formatted as JSON.
         /// </summary>
-        [Option('f', "format", Default = "text", HelpText = "Set format of output (text, json)")]
-        public string Format { get; set; }
+        [Option('j', "json", Default = false, HelpText = "Output readings as JSON")]
+        public bool JsonOutput { get; set; }
     }
 }

--- a/Bme680.Samples/Program.cs
+++ b/Bme680.Samples/Program.cs
@@ -1,9 +1,9 @@
-using CommandLine;
-using Newtonsoft.Json;
 using System;
 using System.Device.I2c;
 using System.Device.I2c.Drivers;
 using System.Threading;
+using CommandLine;
+using Newtonsoft.Json;
 
 namespace Bme680.Samples
 {

--- a/Bme680.Samples/Program.cs
+++ b/Bme680.Samples/Program.cs
@@ -1,3 +1,4 @@
+using CommandLine;
 using System;
 using System.Device.I2c;
 using System.Device.I2c.Drivers;
@@ -11,10 +12,22 @@ namespace Bme680.Samples
     public static class Program
     {
         /// <summary>
+        /// CLI options the program was called with.
+        /// </summary>
+        private static Options _options;
+
+        /// <summary>
         /// Main entry point for the program.
         /// </summary>
-        static void Main()
+        static int Main(string[] args)
         {
+            var parseResult = Parser.Default.ParseArguments<Options>(args).WithParsed(options => _options = options);
+            if (parseResult is NotParsed<Options>)
+            {
+                // Invalid options passed to program, exit with non-ok status code.
+                return -1;
+            }
+
             Console.WriteLine("Hello BME680!");
 
             // The I2C bus ID on the Raspberry Pi 3.

--- a/Bme680.Samples/Program.cs
+++ b/Bme680.Samples/Program.cs
@@ -42,11 +42,14 @@ namespace Bme680.Samples
                     // This prevent us from reading old data from the sensor.
                     if (bme680.HasNewData)
                     {
-                        var temperature = Math.Round(bme680.Temperature.Celsius, 2).ToString("N2");
-                        var pressure = Math.Round(bme680.Pressure / 100, 2).ToString("N2");
-                        var humidity = Math.Round(bme680.Humidity, 2).ToString("N2");
+                        var reading = new
+                        {
+                            Temperature = Math.Round(bme680.Temperature.Celsius, 2).ToString("N2"),
+                            Pressure = Math.Round(bme680.Pressure / 100, 2).ToString("N2"),
+                            Humidity = Math.Round(bme680.Humidity, 2).ToString("N2")
+                        };
 
-                        Console.WriteLine($"{temperature} °c | {pressure} hPa | {humidity} %rH");
+                        Console.WriteLine($"{reading.Temperature} °c | {reading.Pressure} hPa | {reading.Humidity} %rH");
 
                         Thread.Sleep(1000);
                     }

--- a/Bme680.Samples/Program.cs
+++ b/Bme680.Samples/Program.cs
@@ -63,14 +63,13 @@ namespace Bme680.Samples
                             Humidity = Math.Round(bme680.Humidity, 2).ToString("N2")
                         };
 
-                        switch(_options.Format)
+                        if(_options.JsonOutput)
                         {
-                            case "text":
-                                Console.WriteLine($"{reading.Temperature} °c | {reading.Pressure} hPa | {reading.Humidity} %rH");
-                                break;
-                            case "json":
-                                Console.WriteLine(JsonConvert.SerializeObject(reading));
-                                break;
+                            Console.WriteLine(JsonConvert.SerializeObject(reading));
+                        }
+                        else
+                        {
+                            Console.WriteLine($"{reading.Temperature} °c | {reading.Pressure} hPa | {reading.Humidity} %rH");
                         }
 
                         Thread.Sleep(1000);

--- a/Bme680.Samples/Program.cs
+++ b/Bme680.Samples/Program.cs
@@ -22,6 +22,7 @@ namespace Bme680.Samples
         /// </summary>
         static int Main(string[] args)
         {
+            // Parse options passed from the command line.
             var parseResult = Parser.Default.ParseArguments<Options>(args).WithParsed(options => _options = options);
             if (parseResult is NotParsed<Options>)
             {

--- a/Bme680.Samples/Program.cs
+++ b/Bme680.Samples/Program.cs
@@ -30,7 +30,10 @@ namespace Bme680.Samples
                 return -1;
             }
 
-            Console.WriteLine("Hello BME680!");
+            if(_options.Quiet == false)
+            {
+                Console.WriteLine("Hello BME680!");
+            }
 
             // The I2C bus ID on the Raspberry Pi 3.
             const int busId = 1;

--- a/Bme680.Samples/Program.cs
+++ b/Bme680.Samples/Program.cs
@@ -30,7 +30,7 @@ namespace Bme680.Samples
                 return -1;
             }
 
-            if(_options.Quiet == false)
+            if (_options.Quiet == false)
             {
                 Console.WriteLine("Hello BME680!");
             }
@@ -67,7 +67,7 @@ namespace Bme680.Samples
                             Humidity = Math.Round(bme680.Humidity, 2).ToString("N2")
                         };
 
-                        if(_options.JsonOutput)
+                        if (_options.JsonOutput)
                         {
                             Console.WriteLine(JsonConvert.SerializeObject(reading));
                         }

--- a/Bme680.Samples/Program.cs
+++ b/Bme680.Samples/Program.cs
@@ -1,4 +1,5 @@
 using CommandLine;
+using Newtonsoft.Json;
 using System;
 using System.Device.I2c;
 using System.Device.I2c.Drivers;
@@ -62,7 +63,15 @@ namespace Bme680.Samples
                             Humidity = Math.Round(bme680.Humidity, 2).ToString("N2")
                         };
 
-                        Console.WriteLine($"{reading.Temperature} °c | {reading.Pressure} hPa | {reading.Humidity} %rH");
+                        switch(_options.Format)
+                        {
+                            case "text":
+                                Console.WriteLine($"{reading.Temperature} °c | {reading.Pressure} hPa | {reading.Humidity} %rH");
+                                break;
+                            case "json":
+                                Console.WriteLine(JsonConvert.SerializeObject(reading));
+                                break;
+                        }
 
                         Thread.Sleep(1000);
                     }


### PR DESCRIPTION
I needed the output of the sensor in a JSON format for easier parsing, so I tweaked the sample app to take 2 command line arguments:
-j: Outputs the readings in a JSON format
-q: Suppresses any non-reading output

I used CommandLineParser to parse the options from the CLI, so you can also get help output by adding --help to the command.

Not sure if you'd want these changes merged since this makes the sample app a bit more complicated. Thoughts?